### PR TITLE
Nested menus

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ of menus.
 - [Installation](#installation)
 - [Example](#example)
 - [Documentation](#documentation)
+  - [Submenus](#submenus)
   - [Current item](#current-item)
   - [Runtime parameters](#runtime-parameters)
 
@@ -68,6 +69,39 @@ Using the default renderer, assuming that the current url starts with `/posts`, 
 ```
 
 ## Documentation
+
+## Submenus
+
+Every item can have a submenu. They can be nested as deeply as you want (or at least until Ruby starts complaining).
+
+```ruby
+Navtastic.define :main_menu do |menu|
+  menu.item "Home", '/' do |submenu|
+    submenu.item "Posts", '/posts'
+    submenu.item "About", '/about'
+  end
+
+  menu.item "Settings" do |submenu|
+    submenu.item "General", '/settings'
+    submenu.item "Profile", '/settings/profile'
+  end
+end
+```
+
+By default, submenus will be rendered inside the `<li>` tag of the parent item.
+
+```html
+<ul>
+  <li>
+    <a href="/">Parent</a>
+    <ul>
+      <li>
+        <a href="/child">Child</a>
+      </li>
+    </ul>
+  </li>
+</ul>
+```
 
 ### Current item
 

--- a/lib/navtastic/item.rb
+++ b/lib/navtastic/item.rb
@@ -7,6 +7,9 @@ module Navtastic
     # @return [String,nil] the url to link to if item is a link, nil otherwise
     attr_reader :url
 
+    # @return [Menu,nil] the submenu of this item, if defined
+    attr_accessor :submenu
+
     # Create a new item
     #
     # This should not be used directly. Use the {Menu#item} method instead.
@@ -20,6 +23,8 @@ module Navtastic
       @menu = menu
       @name = name
       @url = url
+
+      @submenu = nil
     end
 
     # Check if this item is the current item in the menu
@@ -30,6 +35,11 @@ module Navtastic
     # @return [Bool] if the item is the current item
     def current?
       @menu.current_item == self
+    end
+
+    # @return [Bool] true if the item has a submenu, false other
+    def submenu?
+      !@submenu.nil?
     end
 
     def inspect

--- a/lib/navtastic/renderer.rb
+++ b/lib/navtastic/renderer.rb
@@ -15,15 +15,15 @@ module Navtastic
     # @return [Renderer]
     def self.render(menu)
       new(menu: menu) do
-        root(menu)
+        menu(menu)
       end
     end
 
-    # The render starting point (e.g. root `<ul>` tag)
+    # Starting a new root menu or submenu (e.g. `<ul>` tag)
     #
     # @param menu [Menu]
     # @return [Arbre::HTML::Tag]
-    def root(menu)
+    def menu(menu)
       ul do
         menu.each do |item|
           item_container item
@@ -38,6 +38,8 @@ module Navtastic
     def item_container(item)
       li(class: css_classes_string(item, :item_container)) do
         item_content item
+
+        menu(item.submenu) if item.submenu?
       end
     end
 
@@ -49,7 +51,7 @@ module Navtastic
       if item.url
         a(href: item.url) { item.name }
       else
-        item.name
+        span item.name
       end
     end
 

--- a/spec/demo/index.rhtml
+++ b/spec/demo/index.rhtml
@@ -1,8 +1,14 @@
 <%
 Navtastic.define :main_menu do |menu|
-  menu.item "Home", '/'
-  menu.item "Posts", '/posts'
-  menu.item "About", '/about'
+  menu.item "Home", '/' do |submenu|
+    submenu.item "Posts", '/posts'
+    submenu.item "About", '/about'
+  end
+
+  menu.item "Settings" do |submenu|
+    submenu.item "General", '/settings'
+    submenu.item "Profile", '/settings/profile'
+  end
 end
 %>
 
@@ -11,6 +17,7 @@ end
     <title>Navtastic Demo Server</title>
     <style type="text/css">
       .current { font-weight: bold }
+      .current ul { font-weight: normal }
     </style>
   </head>
 

--- a/spec/navtastic/menu_spec.rb
+++ b/spec/navtastic/menu_spec.rb
@@ -4,19 +4,39 @@ require 'support/matchers/current_item.rb'
 RSpec.describe Navtastic::Menu do
   subject(:menu) do
     menu = described_class.new
-    menu.item "Home"
-    menu.item "Posts", '/posts'
-    menu.item "Featured", '/posts/featured'
+
+    menu.item "Home" do |submenu|
+      submenu.item "Posts", '/posts'
+      submenu.item "Featured", '/posts/featured'
+    end
+
+    menu.item "About", '/about'
+
     menu
   end
 
   describe '.new' do
     subject(:menu) { described_class.new }
 
-    let(:params) { { x: 1 } }
+    context "when the menu has no parent" do
+      specify { expect(menu.items).to be_empty }
+      specify { expect(menu).not_to have_current_item }
 
-    specify { expect(menu.items).to be_empty }
-    specify { expect(menu).not_to have_current_item }
+      it "has a depth of 0" do
+        expect(menu.depth).to eq 0
+      end
+    end
+
+    context "when the menu has a parent" do
+      subject(:submenu) { described_class.new(menu) }
+
+      specify { expect(submenu.items).to be_empty }
+      specify { expect(submenu).not_to have_current_item }
+
+      it "has a depth of parent.depth + 1" do
+        expect(submenu.depth).to eq(menu.depth + 1)
+      end
+    end
   end
 
   describe '#item' do
@@ -56,15 +76,33 @@ RSpec.describe Navtastic::Menu do
         expect(item.url).to eq url
       end
     end
+
+    context "when the item has a submenu" do
+      let(:item) { menu.items.first }
+
+      it "adds the menu to the itme" do
+        expect(item.submenu).not_to eq nil
+      end
+    end
+  end
+
+  describe '#items' do
+    it "includes every item defined in this menu" do
+      expect(menu.items.count).to eq 2
+    end
   end
 
   describe '#each' do
-    specify { expect { |b| menu.each(&b) }.to yield_control.exactly(3).times }
+    specify { expect { |b| menu.each(&b) }.to yield_control.exactly(2).times }
     specify { expect(menu).to all be_a Navtastic::Item }
   end
 
   describe '#[]' do
-    it "returns the item for the given url" do
+    it "returns the item for the given url in this menu" do
+      expect(menu['/about'].name).to eql 'About'
+    end
+
+    it "returns the item for the given url in a submenu" do
       expect(menu['/posts/featured'].name).to eql 'Featured'
     end
 
@@ -91,10 +129,34 @@ RSpec.describe Navtastic::Menu do
     context "when the current url was set" do
       before { menu.current_url = url }
 
-      let(:url) { '/posts' }
+      let(:url) { '/about' }
 
       it "points to the item matching the url" do
         expect(current_item).to eq menu[url]
+      end
+    end
+
+    context "when the current url matches an item in a submenu" do
+      before { menu.current_url = url }
+
+      let(:url) { '/posts' }
+
+      it "points to the item in the submenu" do
+        expect(current_item).to eq menu[url]
+      end
+    end
+
+    context "when the current menu has a parent" do
+      before { menu.current_url = url }
+
+      subject(:submenu) { menu.items.first.submenu }
+
+      let(:url) { '/about' }
+
+      it "asks the parent menu for the current item" do
+        allow(menu).to receive :current_item
+        submenu.current_item
+        expect(menu).to have_received :current_item
       end
     end
   end
@@ -128,8 +190,6 @@ RSpec.describe Navtastic::Menu do
       subject(:menu) do
         menu = described_class.new
         menu.item "Home", '/'
-        menu.item "Posts", '/posts'
-        menu.item "Featured", '/posts/featured'
         menu
       end
 


### PR DESCRIPTION
Allow submenus to be defined on items

Any item can now have a submenu when defined.

```
Navtastic.define :main do |menu|
  menu.item "Home", '/' do |submenu|
    submenu.item "Posts", '/posts'
  end
end
```